### PR TITLE
Adjust tablet landscape button layout

### DIFF
--- a/src/components/congregation/CongregationDrawerDialog.tsx
+++ b/src/components/congregation/CongregationDrawerDialog.tsx
@@ -16,7 +16,8 @@ interface CongregationDrawerDialogProps {
 
 export function CongregationDrawerDialog({ congregationId, onUserAdded }: CongregationDrawerDialogProps) {
   const [open, setOpen] = React.useState(false);
-  const isDesktop = useMediaQuery("(min-width: 768px)");
+  // Consider desktop at >=1280px so medium tablets use floating FAB
+  const isDesktop = useMediaQuery("(min-width: 1280px)");
   const triggerLabel = "Add user to congregation";
 
   const handleAdded = (user: any) => {
@@ -31,7 +32,7 @@ export function CongregationDrawerDialog({ congregationId, onUserAdded }: Congre
     return (
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogTrigger asChild>
-          <Button variant="outline" className="fixed right-4 bottom-[104px] z-40 md:right-6" title={triggerLabel} aria-label={triggerLabel}>
+          <Button variant="outline" className="fixed right-4 bottom-[104px] z-40 md:right-6 lg:right-8 lg:bottom-8" title={triggerLabel} aria-label={triggerLabel}>
             <UserPlus className="h-4 w-4 mr-2" /> Add
           </Button>
         </DialogTrigger>
@@ -56,7 +57,7 @@ export function CongregationDrawerDialog({ congregationId, onUserAdded }: Congre
             type="button"
             aria-label={triggerLabel}
             title={triggerLabel}
-            className="fixed right-4 z-40 h-14 w-14 rounded-full shadow-2xl bg-primary text-primary-foreground hover:shadow-3xl transition-all duration-300 hover:scale-110 active:scale-95 touch-manipulation md:right-6 bottom-[calc(max(env(safe-area-inset-bottom),0px)+80px)] md:bottom-[104px]"
+            className="fixed right-4 z-40 h-14 w-14 rounded-full shadow-2xl bg-primary text-primary-foreground hover:shadow-3xl transition-all duration-300 hover:scale-110 active:scale-95 touch-manipulation md:right-6 bottom-[calc(max(env(safe-area-inset-bottom),0px)+80px)] md:bottom-[104px] lg:h-16 lg:w-16 lg:right-8 lg:bottom-8"
           >
             <UserPlus className="h-6 w-6" />
           </Button>

--- a/src/components/congregation/CongregationUserSearchButton.tsx
+++ b/src/components/congregation/CongregationUserSearchButton.tsx
@@ -22,10 +22,10 @@ export function CongregationUserSearchButton({ congregationId, canEdit, onRefres
 
   return (
     <>
-      {/* Floating Action Button - same positioning as BusinessFloatingButton */}
+      {/* Floating Action Button - aligned with Business FAB; larger and adjusted on lg (tablet landscape) */}
       <Button
         onClick={() => setSearchDrawerOpen(true)}
-        className="fixed right-4 z-40 h-14 w-14 rounded-full shadow-2xl hover:shadow-3xl transition-all duration-300 hover:scale-110 active:scale-95 touch-manipulation md:right-6 bottom-[calc(max(env(safe-area-inset-bottom),0px)+80px)] md:bottom-[104px]"
+        className="fixed right-4 z-40 h-14 w-14 rounded-full shadow-2xl hover:shadow-3xl transition-all duration-300 hover:scale-110 active:scale-95 touch-manipulation md:right-6 bottom-[calc(max(env(safe-area-inset-bottom),0px)+80px)] md:bottom-[104px] lg:h-16 lg:w-16 lg:right-8 lg:bottom-8"
         size="lg"
       >
         <Plus className="h-6 w-6" />

--- a/src/components/fieldservice/FieldServiceDrawerDialog.tsx
+++ b/src/components/fieldservice/FieldServiceDrawerDialog.tsx
@@ -21,7 +21,9 @@ export function FieldServiceDrawerDialog({ userId, triggerLabel = "Field Service
   const [uncontrolledOpen, setUncontrolledOpen] = React.useState(false);
   const open = controlledOpen ?? uncontrolledOpen;
   const setOpen = onOpenChange ?? setUncontrolledOpen;
-  const isDesktop = useMediaQuery("(min-width: 768px)");
+  // Treat true desktop at >=1280px so medium tablets (e.g., iPad landscape)
+  // still use the floating circular trigger like Business view
+  const isDesktop = useMediaQuery("(min-width: 1280px)");
 
   if (isDesktop) {
     return (
@@ -53,7 +55,7 @@ export function FieldServiceDrawerDialog({ userId, triggerLabel = "Field Service
               type="button"
               aria-label={triggerLabel}
               title={triggerLabel}
-              className="fixed right-4 z-40 h-14 w-14 rounded-full shadow-2xl bg-primary text-primary-foreground hover:shadow-3xl transition-all duration-300 hover:scale-110 active:scale-95 touch-manipulation md:right-6 bottom-[calc(max(env(safe-area-inset-bottom),0px)+80px)] md:bottom-[104px]"
+              className="fixed right-4 z-40 h-14 w-14 rounded-full shadow-2xl bg-primary text-primary-foreground hover:shadow-3xl transition-all duration-300 hover:scale-110 active:scale-95 touch-manipulation md:right-6 bottom-[calc(max(env(safe-area-inset-bottom),0px)+80px)] md:bottom-[104px] lg:h-16 lg:w-16 lg:right-8 lg:bottom-8"
             >
               <FilePlus2 className="h-6 w-6" />
             </Button>


### PR DESCRIPTION
Align Home and Congregation view trigger buttons with the Business view on medium tablets by adjusting their style and position.

The previous desktop breakpoint (768px) caused medium tablets in landscape mode to display a non-floating button. By increasing this breakpoint to 1280px, these tablets now correctly use the floating circular FAB, which is then further styled (larger, more right, lower) for optimal placement given the absence of a bottom navigation bar on these larger tablet screens.

---
<a href="https://cursor.com/background-agent?bcId=bc-602d42be-fa2a-4fa6-b18a-c2337fae9091">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-602d42be-fa2a-4fa6-b18a-c2337fae9091">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

