### PR TITLE
Fix Android home swipe scroll (sidebar shell height)

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -139,7 +139,9 @@ function SidebarProvider({
             } as React.CSSProperties
           }
           className={cn(
-            "group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full",
+            // h-svh (not min-h-svh): min-height lets the shell grow with content so inner
+            // overflow-y-auto sections never become scroll containers on mobile (Android).
+            "group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex h-svh max-h-svh min-h-0 w-full",
             className
           )}
           {...props}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The home section uses `overflow-y-auto` on `SectionShell`, but the outer `SidebarProvider` wrapper used `min-h-svh`, which allowed the flex column to grow with content. On mobile (notably Android Chrome), that meant the scrollable region never became a proper scroll container, so swipe scrolling felt broken.

## Changes
- Replace `min-h-svh` with `h-svh max-h-svh min-h-0` on the sidebar wrapper so the main column is viewport-bounded and inner `min-h-0` + `overflow-y-auto` sections can scroll.

## Testing
- `npm run lint` was not available in this environment (no Node/npm). Please run locally if needed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be3425eb-67c7-4c86-a7c8-7c1f4296e25b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be3425eb-67c7-4c86-a7c8-7c1f4296e25b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

