### PR TITLE
Fix intermittent "This page couldn't load" when opening call details from home

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE = "mr-app-v3"; // Updated cache version to force refresh
+const CACHE = "mr-app-v4"; // Updated cache version to force refresh
 const OFFLINE_URL = "/offline";
 
 self.addEventListener("install", (event) => {
@@ -126,10 +126,13 @@ self.addEventListener("fetch", (event) => {
   event.respondWith(
     fetch(req)
       .then((res) => {
-        // Only cache successful same-origin GET responses
+        // Only cache successful same-origin GET responses.
+        // Never cache Next build chunks — stale hashes cause "This page couldn't load" after deploy.
         try {
           const url = new URL(req.url);
-          if ((url.origin === self.location.origin) && res.ok) {
+          const isNextBuildAsset =
+            url.pathname.startsWith("/_next/static/") || url.pathname.startsWith("/_next/chunks/");
+          if (url.origin === self.location.origin && res.ok && !isNextBuildAsset) {
             const copy = res.clone();
             caches.open(CACHE).then((cache) => cache.put(req, copy)).catch(() => {});
           }

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { AppRouteError } from "@/components/shared/AppRouteError";
+
+export default function Error({
+  error,
+  reset,
+  unstable_retry,
+}: {
+  error: Error & { digest?: string };
+  reset?: () => void;
+  unstable_retry?: () => void;
+}) {
+  return <AppRouteError error={error} reset={reset ?? unstable_retry} />;
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { AppRouteError } from "@/components/shared/AppRouteError";
+
+export default function GlobalError({
+  error,
+  reset,
+  unstable_retry,
+}: {
+  error: Error & { digest?: string };
+  reset?: () => void;
+  unstable_retry?: () => void;
+}) {
+  return <AppRouteError error={error} reset={reset ?? unstable_retry} global />;
+}

--- a/src/components/AppChrome.tsx
+++ b/src/components/AppChrome.tsx
@@ -18,6 +18,7 @@ import { cn } from "@/lib/utils";
 // Defer non-critical chrome to reduce initial JS
 const OfflineInit = dynamic(() => import("@/components/OfflineInit"), { ssr: false });
 const ServiceWorkerRegister = dynamic(() => import("@/components/ServiceWorkerRegister"), { ssr: false });
+const ChunkLoadRecovery = dynamic(() => import("@/components/ChunkLoadRecovery"), { ssr: false });
 const SyncBanner = dynamic(() => import("@/components/SyncBanner"), { ssr: false });
 const OnlineBanner = dynamic(() => import("@/components/OnlineBanner"), { ssr: false });
 const BiometricGate = dynamic(() => import("@/components/BiometricGate"), { ssr: false });
@@ -69,6 +70,7 @@ export function AppChrome({ children }: AppChromeProps) {
       <>
         <OfflineInit />
         <ServiceWorkerRegister />
+        <ChunkLoadRecovery />
         <SyncBanner />
         <OnlineBanner />
         <BiometricGate />
@@ -83,6 +85,7 @@ export function AppChrome({ children }: AppChromeProps) {
       
       <OfflineInit />
       <ServiceWorkerRegister />
+      <ChunkLoadRecovery />
       <SyncBanner />
       <OnlineBanner />
       <BiometricGate />

--- a/src/components/ChunkLoadRecovery.tsx
+++ b/src/components/ChunkLoadRecovery.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect } from "react";
+
+const RELOAD_FLAG = "mr-chunk-reload-once";
+
+function isChunkLoadFailure(reason: unknown): boolean {
+  const message =
+    reason instanceof Error
+      ? `${reason.name} ${reason.message}`
+      : typeof reason === "string"
+        ? reason
+        : "";
+  const lower = message.toLowerCase();
+  return (
+    lower.includes("chunkloaderror") ||
+    lower.includes("loading chunk") ||
+    lower.includes("failed to fetch dynamically imported module") ||
+    lower.includes("importing a module script failed")
+  );
+}
+
+/**
+ * After deploys, a stale service-worker cache can reference missing `_next` chunks.
+ * Recover once per session instead of leaving users on the Next global-error screen.
+ */
+export default function ChunkLoadRecovery() {
+  useEffect(() => {
+    const tryRecover = (reason: unknown) => {
+      if (!isChunkLoadFailure(reason)) return;
+      if (typeof window === "undefined") return;
+      if (sessionStorage.getItem(RELOAD_FLAG) === "1") return;
+      sessionStorage.setItem(RELOAD_FLAG, "1");
+      window.location.reload();
+    };
+
+    const onError = (event: ErrorEvent) => {
+      tryRecover(event.error ?? event.message);
+    };
+
+    const onRejection = (event: PromiseRejectionEvent) => {
+      tryRecover(event.reason);
+    };
+
+    window.addEventListener("error", onError);
+    window.addEventListener("unhandledrejection", onRejection);
+    return () => {
+      window.removeEventListener("error", onError);
+      window.removeEventListener("unhandledrejection", onRejection);
+    };
+  }, []);
+
+  return null;
+}

--- a/src/components/home/CallHistory.tsx
+++ b/src/components/home/CallHistory.tsx
@@ -71,6 +71,7 @@ import {
   studyBibleSectionToggle,
 } from "@/lib/theme/study-bible-dark";
 import { DetailsDrawer } from "@/components/shared/DetailsDrawer";
+import { toast } from "@/components/ui/sonner";
 
 interface CallHistoryProps {
   userId: string;
@@ -240,6 +241,7 @@ export function CallHistory({
   const selectedCallsContactDetailsRef = useRef<CallsContactSnapshot | null>(null);
   const selectedCallsEstablishmentDetailsRef = useRef<CallsEstablishmentSnapshot | null>(null);
   const callsContactSubdrawerOpenRef = useRef(false);
+  const callsDetailsOpenRequestRef = useRef(0);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const hasFocusedRef = useRef(false);
   const searchDebounceTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -789,48 +791,209 @@ export function CallHistory({
           todo: MyOpenCallTodoItem;
         }
   ) {
+    const requestId = ++callsDetailsOpenRequestRef.current;
+    const isStale = () => requestId !== callsDetailsOpenRequestRef.current;
+
     const contactId =
       target.kind === "visit" ? target.visit.contact_id : target.todo.contact_id;
     const establishmentId =
       target.kind === "visit" ? target.visit.establishment_id : target.todo.establishment_id;
 
-    if (contactId) {
-      const fallbackName =
-        target.kind === "visit"
-          ? target.visit.contact_name ?? "Contact"
-          : target.todo.context_name ?? "Contact";
-      const fallbackStatus =
-        target.kind === "visit"
-          ? target.visit.contact_status ?? "potential"
-          : target.todo.context_status ?? "potential";
+    try {
+      if (contactId) {
+        const fallbackName =
+          target.kind === "visit"
+            ? target.visit.contact_name ?? "Contact"
+            : target.todo.context_name ?? "Contact";
+        const fallbackStatus =
+          target.kind === "visit"
+            ? target.visit.contact_status ?? "potential"
+            : target.todo.context_status ?? "potential";
+        const fallbackEstablishmentName =
+          target.kind === "visit"
+            ? target.visit.establishment_name ?? null
+            : target.todo.context_establishment_name ?? null;
+        const fallbackEstablishmentStatus =
+          target.kind === "visit"
+            ? target.visit.establishment_status ?? null
+            : target.todo.context_establishment_status ?? null;
+
+        const fallbackStub: CallsContactSnapshot = {
+          contact: {
+            id: contactId,
+            name: fallbackName,
+            statuses: [fallbackStatus as ContactStatus],
+            note: null,
+            establishment_id: establishmentId ?? null,
+            establishment_name: fallbackEstablishmentName,
+            publisher_id: null,
+            lat: null,
+            lng: null,
+          },
+          visits: [],
+          establishment: establishmentId
+            ? {
+                id: establishmentId,
+                name: fallbackEstablishmentName ?? "",
+                area: null,
+                statuses: fallbackEstablishmentStatus ? [fallbackEstablishmentStatus] : null,
+              }
+            : null,
+        };
+
+        const { snapshot, hadWarmCache } = await resolveContactDetailsSnapshot(
+          contactId,
+          callsContactCacheRef.current,
+          fallbackStub
+        );
+        if (isStale()) return;
+
+        setSelectedCallsContactDetails(snapshot);
+        setSelectedCallsEstablishmentDetails(null);
+        setCallsContactSubdrawerOpen(false);
+        setCallsDetailsDrawerOpen(true);
+        setIsLoadingCallsDetails(!hadWarmCache);
+
+        try {
+          const details = await getContactDetails(contactId);
+          if (isStale()) return;
+          if (!details) {
+            if (!hadWarmCache) {
+              setSelectedCallsContactDetails(null);
+              setCallsDetailsDrawerOpen(false);
+              toast.error("Could not load contact details");
+            }
+            return;
+          }
+          const nextSnapshot: CallsContactSnapshot = {
+            contact: details.contact,
+            visits: details.visits,
+            establishment: details.establishment,
+          };
+          callsContactCacheRef.current.set(contactId, nextSnapshot);
+          setSelectedCallsContactDetails(nextSnapshot);
+        } finally {
+          if (!isStale()) setIsLoadingCallsDetails(false);
+        }
+        return;
+      }
+
+      if (establishmentId) {
+        const fallbackName =
+          target.kind === "visit"
+            ? target.visit.establishment_name ?? "Establishment"
+            : target.todo.context_name ?? "Establishment";
+        const fallbackStatus =
+          target.kind === "visit"
+            ? target.visit.establishment_status ?? "for_scouting"
+            : target.todo.context_establishment_status ||
+              target.todo.context_status ||
+              "for_scouting";
+        const fallbackArea =
+          target.kind === "visit"
+            ? target.visit.establishment_area ?? null
+            : target.todo.context_area ?? null;
+
+        const fallbackStub: CallsEstablishmentSnapshot = {
+          establishment: {
+            id: establishmentId,
+            name: fallbackName,
+            area: fallbackArea,
+            description: null,
+            floor: null,
+            note: null,
+            statuses: [fallbackStatus],
+            lat: null,
+            lng: null,
+          },
+          visits: [],
+          contacts: [],
+        };
+
+        const { snapshot, hadWarmCache } = await resolveEstablishmentDetailsSnapshot(
+          establishmentId,
+          callsEstablishmentCacheRef.current,
+          fallbackStub
+        );
+        if (isStale()) return;
+
+        setSelectedCallsEstablishmentDetails(snapshot);
+        setSelectedCallsContactDetails(null);
+        setCallsContactSubdrawerOpen(false);
+        setCallsDetailsDrawerOpen(true);
+        setIsLoadingCallsDetails(!hadWarmCache);
+
+        try {
+          const details = await getEstablishmentDetails(establishmentId);
+          if (isStale()) return;
+          if (!details) {
+            if (!hadWarmCache) {
+              setSelectedCallsEstablishmentDetails(null);
+              setCallsDetailsDrawerOpen(false);
+              toast.error("Could not load establishment details");
+            }
+            return;
+          }
+          const nextSnapshot: CallsEstablishmentSnapshot = {
+            establishment: details.establishment,
+            visits: details.visits,
+            contacts: details.contacts,
+          };
+          callsEstablishmentCacheRef.current.set(establishmentId, nextSnapshot);
+          setSelectedCallsEstablishmentDetails(nextSnapshot);
+        } finally {
+          if (!isStale()) setIsLoadingCallsDetails(false);
+        }
+        return;
+      }
+
+      if (target.kind === "visit" && onVisitClick) {
+        onVisitClick(target.visit);
+        return;
+      }
+
+      toast.error("This call is not linked to a contact or establishment");
+    } catch (error) {
+      if (isStale()) return;
+      console.error("openCallsDetailsDrawer failed", error);
+      setCallsDetailsDrawerOpen(false);
+      setSelectedCallsContactDetails(null);
+      setSelectedCallsEstablishmentDetails(null);
+      toast.error("Could not open details", {
+        description: error instanceof Error ? error.message : undefined,
+      });
+    }
+  }
+
+  async function openCallsContactSubdrawer(contact: ContactWithDetails) {
+    const contactId = contact.id;
+    if (!contactId) return;
+
+    const requestId = ++callsDetailsOpenRequestRef.current;
+    const isStale = () => requestId !== callsDetailsOpenRequestRef.current;
+
+    try {
+      const establishment =
+        selectedCallsEstablishmentDetails?.establishment &&
+        selectedCallsEstablishmentDetails.establishment.id === contact.establishment_id
+          ? selectedCallsEstablishmentDetails.establishment
+          : null;
       const fallbackEstablishmentName =
-        target.kind === "visit"
-          ? target.visit.establishment_name ?? null
-          : target.todo.context_establishment_name ?? null;
-      const fallbackEstablishmentStatus =
-        target.kind === "visit"
-          ? target.visit.establishment_status ?? null
-          : target.todo.context_establishment_status ?? null;
+        establishment?.name ?? contact.establishment_name ?? null;
+      const fallbackStatuses =
+        establishment?.statuses && establishment.statuses.length > 0
+          ? establishment.statuses
+          : null;
 
       const fallbackStub: CallsContactSnapshot = {
-        contact: {
-          id: contactId,
-          name: fallbackName,
-          statuses: [fallbackStatus as ContactStatus],
-          note: null,
-          establishment_id: establishmentId ?? null,
-          establishment_name: fallbackEstablishmentName,
-          publisher_id: null,
-          lat: null,
-          lng: null,
-        },
+        contact,
         visits: [],
-        establishment: establishmentId
+        establishment: contact.establishment_id
           ? {
-              id: establishmentId,
+              id: contact.establishment_id,
               name: fallbackEstablishmentName ?? "",
-              area: null,
-              statuses: fallbackEstablishmentStatus ? [fallbackEstablishmentStatus] : null,
+              area: establishment?.area ?? null,
+              statuses: fallbackStatuses,
             }
           : null,
       };
@@ -840,15 +1003,23 @@ export function CallHistory({
         callsContactCacheRef.current,
         fallbackStub
       );
+      if (isStale()) return;
 
       setSelectedCallsContactDetails(snapshot);
-      setSelectedCallsEstablishmentDetails(null);
-      setCallsDetailsDrawerOpen(true);
-      setIsLoadingCallsDetails(!hadWarmCache);
+      setCallsContactSubdrawerOpen(true);
+      setIsLoadingCallsContactDetails(!hadWarmCache);
 
       try {
         const details = await getContactDetails(contactId);
-        if (!details) return;
+        if (isStale()) return;
+        if (!details) {
+          if (!hadWarmCache) {
+            setCallsContactSubdrawerOpen(false);
+            setSelectedCallsContactDetails(null);
+            toast.error("Could not load contact details");
+          }
+          return;
+        }
         const nextSnapshot: CallsContactSnapshot = {
           contact: details.contact,
           visits: details.visits,
@@ -857,126 +1028,15 @@ export function CallHistory({
         callsContactCacheRef.current.set(contactId, nextSnapshot);
         setSelectedCallsContactDetails(nextSnapshot);
       } finally {
-        setIsLoadingCallsDetails(false);
+        if (!isStale()) setIsLoadingCallsContactDetails(false);
       }
-      return;
-    }
-
-    if (establishmentId) {
-      const fallbackName =
-        target.kind === "visit"
-          ? target.visit.establishment_name ?? "Establishment"
-          : target.todo.context_name ?? "Establishment";
-      const fallbackStatus =
-        target.kind === "visit"
-          ? target.visit.establishment_status ?? "for_scouting"
-          : target.todo.context_establishment_status ||
-            target.todo.context_status ||
-            "for_scouting";
-      const fallbackArea =
-        target.kind === "visit"
-          ? target.visit.establishment_area ?? null
-          : target.todo.context_area ?? null;
-
-      const fallbackStub: CallsEstablishmentSnapshot = {
-        establishment: {
-          id: establishmentId,
-          name: fallbackName,
-          area: fallbackArea,
-          description: null,
-          floor: null,
-          note: null,
-          statuses: [fallbackStatus],
-          lat: null,
-          lng: null,
-        },
-        visits: [],
-        contacts: [],
-      };
-
-      const { snapshot, hadWarmCache } = await resolveEstablishmentDetailsSnapshot(
-        establishmentId,
-        callsEstablishmentCacheRef.current,
-        fallbackStub
-      );
-
-      setSelectedCallsEstablishmentDetails(snapshot);
-      setSelectedCallsContactDetails(null);
-      setCallsDetailsDrawerOpen(true);
-      setIsLoadingCallsDetails(!hadWarmCache);
-
-      try {
-        const details = await getEstablishmentDetails(establishmentId);
-        if (!details) return;
-        const nextSnapshot: CallsEstablishmentSnapshot = {
-          establishment: details.establishment,
-          visits: details.visits,
-          contacts: details.contacts,
-        };
-        callsEstablishmentCacheRef.current.set(establishmentId, nextSnapshot);
-        setSelectedCallsEstablishmentDetails(nextSnapshot);
-      } finally {
-        setIsLoadingCallsDetails(false);
-      }
-      return;
-    }
-
-    if (target.kind === "visit" && onVisitClick) {
-      onVisitClick(target.visit);
-    }
-  }
-
-  async function openCallsContactSubdrawer(contact: ContactWithDetails) {
-    const contactId = contact.id;
-    if (!contactId) return;
-
-    const establishment =
-      selectedCallsEstablishmentDetails?.establishment &&
-      selectedCallsEstablishmentDetails.establishment.id === contact.establishment_id
-        ? selectedCallsEstablishmentDetails.establishment
-        : null;
-    const fallbackEstablishmentName =
-      establishment?.name ?? contact.establishment_name ?? null;
-    const fallbackStatuses =
-      establishment?.statuses && establishment.statuses.length > 0
-        ? establishment.statuses
-        : null;
-
-    const fallbackStub: CallsContactSnapshot = {
-      contact,
-      visits: [],
-      establishment: contact.establishment_id
-        ? {
-            id: contact.establishment_id,
-            name: fallbackEstablishmentName ?? "",
-            area: establishment?.area ?? null,
-            statuses: fallbackStatuses,
-          }
-        : null,
-    };
-
-    const { snapshot, hadWarmCache } = await resolveContactDetailsSnapshot(
-      contactId,
-      callsContactCacheRef.current,
-      fallbackStub
-    );
-
-    setSelectedCallsContactDetails(snapshot);
-    setCallsContactSubdrawerOpen(true);
-    setIsLoadingCallsContactDetails(!hadWarmCache);
-
-    try {
-      const details = await getContactDetails(contactId);
-      if (!details) return;
-      const nextSnapshot: CallsContactSnapshot = {
-        contact: details.contact,
-        visits: details.visits,
-        establishment: details.establishment,
-      };
-      callsContactCacheRef.current.set(contactId, nextSnapshot);
-      setSelectedCallsContactDetails(nextSnapshot);
-    } finally {
-      setIsLoadingCallsContactDetails(false);
+    } catch (error) {
+      if (isStale()) return;
+      console.error("openCallsContactSubdrawer failed", error);
+      setCallsContactSubdrawerOpen(false);
+      toast.error("Could not open contact details", {
+        description: error instanceof Error ? error.message : undefined,
+      });
     }
   }
 
@@ -2180,14 +2240,19 @@ export function CallHistory({
       </FormDrawerRoot>
 
       <DetailsDrawer
-        open={callsDetailsDrawerOpen}
+        open={
+          callsDetailsDrawerOpen &&
+          Boolean(selectedCallsContactDetails || selectedCallsEstablishmentDetails)
+        }
         onOpenChange={(open) => {
+          if (!open) {
+            callsDetailsOpenRequestRef.current += 1;
+          }
           setCallsDetailsDrawerOpen(open);
           if (!open) {
             setSelectedCallsEstablishmentDetails(null);
             setSelectedCallsContactDetails(null);
             setCallsContactSubdrawerOpen(false);
-            setSelectedCallsContactDetails(null);
             setCallsDetailsEntityEditOpen(false);
             setCallsContactSubdrawerEntityEditOpen(false);
           }
@@ -2195,6 +2260,7 @@ export function CallHistory({
         entityName={callsDetailsDrawerTitle.name}
         titleStatus={callsDetailsDrawerTitle.titleStatus}
         layout={callsDrawerTabletLayout ? "tablet" : "phone"}
+        stackAboveParentSheet={!callsDrawerTabletLayout}
         contentClassName={cn(
           "border-border dark:border-[#1c1921] text-foreground dark:text-[#fffaff]",
           callsMainDetailsPanelClass

--- a/src/components/home/HomeTodoCard.tsx
+++ b/src/components/home/HomeTodoCard.tsx
@@ -3578,11 +3578,15 @@ export function HomeTodoCard({
   const detailsAndEditorLayers = (
     <>
       <DetailsDrawer
-        open={todoDetailsDrawerOpen}
+        open={
+          todoDetailsDrawerOpen &&
+          Boolean(selectedContactDetails || selectedTodoDetails)
+        }
         onOpenChange={handleTodoDetailsDrawerChange}
         entityName={todoDetailsDrawerTitle.name}
         titleStatus={todoDetailsDrawerTitle.titleStatus}
         layout={isTodoDetailsSideLayout ? "tablet" : "phone"}
+        stackAboveParentSheet={!isTodoDetailsSideLayout && drawerOpen}
         contentClassName={todoDetailsSheetPanelClass}
         bodyClassName="space-y-3"
       >

--- a/src/components/shared/AppRouteError.tsx
+++ b/src/components/shared/AppRouteError.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { studyBibleDarkClasses } from "@/lib/theme/study-bible-dark";
+import { cn } from "@/lib/utils";
+
+export interface AppRouteErrorProps {
+  error: Error & { digest?: string };
+  reset?: () => void;
+  /** When true, render `<html>` / `<body>` for global-error.tsx. */
+  global?: boolean;
+}
+
+function isChunkLoadError(error: Error): boolean {
+  const message = error.message?.toLowerCase() ?? "";
+  const name = error.name?.toLowerCase() ?? "";
+  return (
+    name.includes("chunkload") ||
+    message.includes("loading chunk") ||
+    message.includes("failed to fetch dynamically imported module") ||
+    message.includes("importing a module script failed")
+  );
+}
+
+export function AppRouteError({ error, reset, global = false }: AppRouteErrorProps) {
+  useEffect(() => {
+    console.error("[AppRouteError]", error);
+  }, [error]);
+
+  const handleReload = () => {
+    if (typeof window !== "undefined") {
+      window.location.reload();
+    }
+  };
+
+  const handleBack = () => {
+    if (typeof window !== "undefined") {
+      if (window.history.length > 1) {
+        window.history.back();
+      } else {
+        window.location.assign("/");
+      }
+    }
+  };
+
+  const handleRetry = () => {
+    if (reset) {
+      reset();
+      return;
+    }
+    handleReload();
+  };
+
+  const chunkStale = isChunkLoadError(error);
+
+  const content = (
+    <div
+      className={cn(
+        "flex min-h-[100dvh] flex-col items-center justify-center gap-6 px-6 py-12 text-center",
+        studyBibleDarkClasses.page
+      )}
+    >
+      <AlertTriangle className="h-12 w-12 text-[#ded6e7]" aria-hidden />
+      <div className="space-y-2 max-w-sm">
+        <h1 className="text-xl font-bold text-[#fffaff]">
+          {chunkStale ? "App update available" : "Something went wrong"}
+        </h1>
+        <p className="text-sm text-[#ded6e7]">
+          {chunkStale
+            ? "A newer version of the app is available. Reload to continue."
+            : "Reload to try again, or go back to the previous screen."}
+        </p>
+      </div>
+      <div className="flex w-full max-w-xs flex-col gap-3 sm:flex-row sm:justify-center">
+        <Button type="button" className="w-full sm:w-auto" onClick={handleRetry}>
+          Reload
+        </Button>
+        <Button type="button" variant="outline" className="w-full sm:w-auto" onClick={handleBack}>
+          Back
+        </Button>
+      </div>
+    </div>
+  );
+
+  if (global) {
+    return (
+      <html lang="en">
+        <body className="antialiased bg-[#24231f] text-[#fffaff]">{content}</body>
+      </html>
+    );
+  }
+
+  return content;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On mobile, tapping a call in the **Calls** drawer on the home page sometimes showed Next.js’s full-screen **“This page couldn’t load”** screen (Reload / Back) instead of contact/establishment details.

## Root cause

1. **Drawer stacking** — The main Calls details `DetailsDrawer` opened as a sibling modal without `stackAboveParentSheet`, while the Calls list drawer stayed open underneath. Vaul can dismiss or fight the parent sheet in that setup (same class of bug fixed for To-Do contact subdrawers in #4c80aca, but the **main** Calls details sheet was missed).

2. **Uncaught async errors / races** — `openCallsDetailsDrawer` had no request cancellation or `try/catch`. Fast taps or failed `getContactDetails` / `getEstablishmentDetails` could leave bad state or throw to the root boundary.

3. **Stale PWA chunks (secondary)** — The service worker cached all same-origin GETs, including `/_next/static/*`. After deploys, cached HTML can reference missing chunks → global error. SW now skips Next build assets; `ChunkLoadRecovery` reloads once on chunk failures.

## Fix

- **CallHistory**: `stackAboveParentSheet` on phone details drawer; stale-request guard; error toasts; only open drawer when snapshot exists.
- **HomeTodoCard**: Same stacking fix for the main to-do details drawer when the list drawer is open (audit).
- **SW** `mr-app-v4`: do not cache `/_next/static` or `/_next/chunks`.
- **App error UI**: `app/error.tsx`, `app/global-error.tsx`, and `ChunkLoadRecovery` with Study Bible styling instead of the default black Next screen.

## How to verify

1. On iPhone PWA (or mobile Safari), open Home → Calls → tap several visits/todos quickly.
2. Details should stack above the list drawer without crashing.
3. After a deploy, reload once if prompted; chunk errors should recover automatically.

## Similar areas audited

| Flow | `stackAboveParentSheet` on main details |
|------|----------------------------------------|
| Home Calls drawer | Fixed in this PR |
| Home To-Do drawer | Fixed in this PR |
| Home To-Do contact subdrawer | Already had it |
| Ministry contacts drawer | Already had it |
| BWI stacked contact details | Already had it |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e10331f-b2cd-4cdc-a8e9-8388fb3a8596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e10331f-b2cd-4cdc-a8e9-8388fb3a8596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

