### PR TITLE
Show Ministry contact FAB actions

### DIFF
--- a/src/components/business/TodoForm.tsx
+++ b/src/components/business/TodoForm.tsx
@@ -12,8 +12,6 @@ import { X, Plus, Calendar, Users, FileText, Link2 } from "lucide-react";
 import { NestedFormPickerDrawerRoot, NestedFormPickerDrawerContent } from "@/components/shared/FormDrawerPhone";
 import { drawerFormScrollPadTightClass } from "@/lib/theme/form-drawer-phone";
 import {
-  Drawer,
-  DrawerContent,
   DrawerHeader,
   DrawerThinRightContent,
   DrawerTitle,

--- a/src/components/business/TodoForm.tsx
+++ b/src/components/business/TodoForm.tsx
@@ -38,6 +38,15 @@ type PublisherSlot = { type: "publisher"; id: string } | { type: "guest"; name: 
 const PARTICIPANTS_CACHE_KEY = "business:participants:local:v1";
 const GUEST_NAMES_CACHE_KEY = "business:guest-names:local:v1";
 
+function broadcastTodosMutated() {
+  try {
+    window.dispatchEvent(new CustomEvent("business-todos-mutated"));
+    window.dispatchEvent(new CustomEvent("app-business-refresh"));
+  } catch {
+    /* ignore */
+  }
+}
+
 /** Quick-fill buttons for new establishment to-dos (not shown on contact/contact forms). */
 const NEW_TODO_BODY_PRESETS = [
   { label: "Replenish", body: "Replenish" },
@@ -263,6 +272,7 @@ export function TodoForm({
         });
         if (ok) {
           toast.success("To-do updated.");
+          broadcastTodosMutated();
           onSaved();
         } else {
           toast.error("Failed to update to-do");
@@ -280,6 +290,7 @@ export function TodoForm({
         });
         if (todo) {
           toast.success("To-do added.");
+          broadcastTodosMutated();
           onSaved();
         } else {
           toast.error("Failed to add to-do");

--- a/src/components/congregation/MinistrySection.tsx
+++ b/src/components/congregation/MinistrySection.tsx
@@ -1046,6 +1046,7 @@ export function MinistrySection({
           open={contactsDrawerOpen}
           onOpenChange={setContactsDrawerOpen}
           title="Contacts"
+          skipFabRootInert={Boolean(selectedContact)}
           className={cn("dark:border-[#1c1921] dark:bg-[#181714] text-[#1a1820] dark:text-[#fffaff]", ministryContactsPanelShade)}
           headerClassName="text-center"
           bodyClassName="flex min-h-0 flex-1 flex-col overflow-hidden !pb-0 max-xl:!pb-0"

--- a/src/components/shared/UnifiedFab.tsx
+++ b/src/components/shared/UnifiedFab.tsx
@@ -73,6 +73,7 @@ type FabActionKey =
   | "congregation-contact"
   | "congregation-user"
   | "congregation-visit"
+  | "congregation-todo"
   | "congregation-schedule"
   | "field-service"
   | "home-edit-todos"
@@ -220,11 +221,16 @@ export function UnifiedFab({
       }
     }
 
-    if (currentSection === "congregation" && canManageCongregation) {
-      if (isCongregationAdminTab) {
+    if (currentSection === "congregation") {
+      if (isCongregationMinistryTab && isCongregationDetails) {
+        items.push(
+          { key: "congregation-visit", label: "New Call", icon: <FilePlus2 className="size-6" /> },
+          { key: "congregation-todo", label: "New To-Do", icon: <ListTodo className="size-6" /> }
+        );
+      } else if (!canManageCongregation) {
+        // Ministry contact details use personal call/to-do actions above; admin creation is elder/admin only.
+      } else if (isCongregationAdminTab) {
         items.push({ key: "congregation-schedule", label: "New Schedule", icon: <Calendar className="size-6" /> });
-      } else if (isCongregationMinistryTab && isCongregationDetails) {
-        items.push({ key: "congregation-visit", label: "New Call", icon: <FilePlus2 className="size-6" /> });
       } else if (isCongregationMinistryTab) {
         items.push({ key: "congregation-contact", label: "Add Contact", icon: <UserPlus className="size-6" /> });
       } else {
@@ -688,6 +694,7 @@ export function UnifiedFab({
         onOpenChange={(open) => setOpenKey(open ? "congregation-visit" : null)}
         title="New Call"
         headerClassName="text-center"
+        stackAboveStackedParentSheet
       >
         <CallForm
           establishments={[]}
@@ -696,6 +703,24 @@ export function UnifiedFab({
           contactId={congregationSelectedContact?.id}
           contactName={congregationSelectedContact?.name}
           contactStatus={congregationSelectedContact ? getContactPrimaryStatus(congregationSelectedContact) : undefined}
+          onSaved={() => setOpenKey(null)}
+        />
+      </FormModal>
+
+      <FormModal
+        open={openKey === "congregation-todo"}
+        onOpenChange={(open) => setOpenKey(open ? "congregation-todo" : null)}
+        title="New To-Do"
+        headerClassName="text-center"
+        stackAboveStackedParentSheet
+        className="w-[min(100vw,48rem)] md:max-h-[100lvh]"
+      >
+        <TodoForm
+          establishments={[]}
+          selectedEstablishmentId="none"
+          disableEstablishmentSelect
+          contactId={congregationSelectedContact?.id}
+          contactName={congregationSelectedContact?.name}
           onSaved={() => setOpenKey(null)}
         />
       </FormModal>

--- a/src/components/shared/UnifiedFab.tsx
+++ b/src/components/shared/UnifiedFab.tsx
@@ -130,7 +130,11 @@ export function UnifiedFab({
   }, []);
 
   useEffect(() => {
-    if (openKey !== "business-bulk-todos") setBulkTodoTabletTier(3);
+    if (openKey === "business-bulk-todos") return;
+    const resetTimer = window.setTimeout(() => {
+      setBulkTodoTabletTier(3);
+    }, 0);
+    return () => window.clearTimeout(resetTimer);
   }, [openKey]);
 
   const getDraftBulkTodoKind = (): "new" | "edit" | "mixed" => {
@@ -269,7 +273,6 @@ export function UnifiedFab({
 
     return items;
   }, [
-    businessTab,
     canManageCongregation,
     currentSection,
     homeDetailsFab,
@@ -309,9 +312,11 @@ export function UnifiedFab({
   }, []);
 
   useEffect(() => {
-    if (openKey === "business-bulk-todos") {
+    if (openKey !== "business-bulk-todos") return;
+    const syncTimer = window.setTimeout(() => {
       setBulkSavedEditRowCount(readBulkDraftSavedEditCount());
-    }
+    }, 0);
+    return () => window.clearTimeout(syncTimer);
   }, [openKey]);
 
   const bulkFabDocked = openKey === "business-bulk-todos";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Show both New Call and New To-Do FAB actions for selected Congregation Ministry contacts.
- Keep the FAB visible when a contact details sheet is stacked above the Ministry contacts drawer.
- Broadcast to-do mutations after standalone to-do saves so visible contact to-do cards refresh immediately.
- Clean up touched-file lint issues in the FAB/to-do files.

## Testing
- Passed: `npx eslint src/components/shared/UnifiedFab.tsx src/components/congregation/MinistrySection.tsx src/components/business/TodoForm.tsx`
- Note: `npm run lint` currently fails on pre-existing unrelated repo-wide lint issues (for example scripts using `require()`, existing `any` usage, and existing React hook lint findings outside this change).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8c80102-246c-4a4b-b9c1-bd50abef5c2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8c80102-246c-4a4b-b9c1-bd50abef5c2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

